### PR TITLE
Release v0.1.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jasonbahl
 Tags: GraphQL, WPGraphQL, GraphiQL, IDE, DevTools, Developer Tools, Tooling, Testing, Productivity, Headless, Gatsby, React, NextJS
 Requires at least: 5.5
 Requires PHP: 7.1
-Stable Tag: 0.1.2
+Stable Tag: 0.1.3
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -14,6 +14,13 @@ WPGraphiQL is a free, open source WordPress plugin that brings the GraphiQL IDE 
 This plugin is intended to be used with WPGraphQL (https://wordpress.org/plugins/wp-graphql)
 
 == Changelog ==
+
+= 0.1.3 =
+
+**New Feature**
+
+- ([#16](https://github.com/wp-graphql/wp-graphiql-2/pull/16)): Fixes a bug where the variables were always being reset to a hardcoded value.
+
 
 = 0.1.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ This plugin is intended to be used with WPGraphQL (https://wordpress.org/plugins
 
 = 0.1.3 =
 
-**New Feature**
+**Chores/Bugfixes**
 
 - ([#16](https://github.com/wp-graphql/wp-graphiql-2/pull/16)): Fixes a bug where the variables were always being reset to a hardcoded value.
 

--- a/wp-graphiql-2.php
+++ b/wp-graphiql-2.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WPGraphiQL 2.0
- * Version: 0.1.2
+ * Version: 0.1.3
  * Description: This is the temporary home of the WPGraphiQL 2.0 plugin which will eventually be merged into WPGraphQL core. New features will be iterated on in this repo and progressively added to WPGraphQL core.
  * Plugin URI: https://github.com/wp-graphql/wp-graphiql-2
  * Author: WPGraphQL
@@ -144,7 +144,7 @@ function graphiql_enqueue_query_composer() {
  * that allows the user to toggle the fullscreen mode
  */
 function graphiql_enqueue_fullscreen_toggle() {
-	
+
 	$fullscreen_toggle_asset_file = include( plugin_dir_path( __FILE__ ) . 'build/graphiqlFullscreenToggle.asset.php');
 
 	wp_enqueue_script(
@@ -161,5 +161,5 @@ function graphiql_enqueue_fullscreen_toggle() {
 		[ 'wp-components' ],
 		$fullscreen_toggle_asset_file['version']
 	);
-	
+
 }


### PR DESCRIPTION
# Release Notes

## Chores/Bugfixes

- ([#16](https://github.com/wp-graphql/wp-graphiql-2/pull/16)): Fixes a bug where the variables were always being reset to a hardcoded value.
